### PR TITLE
feat(clipboard): support usage of text clipboard through WSL and SSH

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ crate-type = ["cdylib"]
 
 [dependencies]
 arboard = { version = "3", features = ["wayland-data-control"] }
+base64 = "0.13.0"
+duct = "0.13.5"
+wsl = "0.1.0"
 napi = { version = "2", default-features = false, features = ["napi3"] }
 napi-derive = "2"
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Manipulate Clipboard in Node.js via native API.
 
-It's a Node.js binding for [1Password/aboard](https://github.com/1Password/arboard)
+It's a Node.js binding for [1Password/aboard](https://github.com/1Password/arboard) with additions from [rgwood/clipboard-anywhere](https://github.com/rgwood/clipboard-anywhere)
 
 [![install size](https://packagephobia.com/badge?p=@napi-rs/clipboard)](https://packagephobia.com/result?p=@napi-rs/clipboard)
 [![Downloads](https://img.shields.io/npm/dm/@napi-rs/clipboard.svg?sanitize=true)](https://npmcharts.com/compare/@napi-rs/clipboard?minimal=true)

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,10 @@
 
 export class Clipboard {
   constructor()
+  /**
+   * Copy text to the clipboard. Has special handling for WSL and SSH sessions, otherwise
+   * falls back to the cross-platform `clipboard` crate
+   */
   setText(text: string): void
   getText(): string
   /** Returns a buffer contains the raw RGBA pixels data */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,10 @@
 extern crate napi_derive;
 
 use std::borrow::Cow;
+use std::env;
+use std::io::Write;
+use std::process::{Command, Stdio};
+use duct::cmd;
 
 use napi::{bindgen_prelude::*, JsBuffer};
 
@@ -25,18 +29,37 @@ impl Clipboard {
     })
   }
 
+  /// Copy text to the clipboard. Has special handling for WSL and SSH sessions, otherwise
+  /// falls back to the cross-platform `clipboard` crate
   #[napi]
   pub fn set_text(&mut self, text: String) -> Result<()> {
-    self
-      .inner
-      .set_text(text)
-      .map_err(clipboard_error_to_js_error)?;
+    if wsl::is_wsl() {
+      set_wsl_clipboard(text)?;
+    } else if env::var("SSH_CLIENT").is_ok() {
+      // we're in an SSH session, so set the clipboard using OSC 52 escape sequence
+      set_clipboard_osc_52(text);
+    } else {
+      // we're probably running on a host/primary OS, so use the default clipboard
+      self
+        .inner
+        .set_text(text)
+        .map_err(clipboard_error_to_js_error)?;
+    }
+
     Ok(())
   }
 
   #[napi]
   pub fn get_text(&mut self) -> Result<String> {
-    self.inner.get_text().map_err(clipboard_error_to_js_error)
+    if wsl::is_wsl() {
+      let stdout = cmd!("powershell.exe", "get-clipboard").read()?;
+      Ok(stdout.trim().to_string())
+    } else if env::var("SSH_CLIENT").is_ok() {
+      Err(Error::new(Status::GenericFailure, "SSH clipboard not supported"))
+    } else {
+      // we're probably running on a host/primary OS, so use the default clipboard
+      self.inner.get_text().map_err(clipboard_error_to_js_error)
+    }
   }
 
   #[napi]
@@ -71,4 +94,22 @@ impl Clipboard {
       })
       .map_err(clipboard_error_to_js_error)
   }
+}
+
+/// Set the clipboard contents using OSC 52 (picked up by most terminals)
+fn set_clipboard_osc_52(text: String) {
+  print!("\x1B]52;c;{}\x07", base64::encode(text));
+}
+
+/// Set the Windows clipboard using clip.exe in WSL
+fn set_wsl_clipboard(s: String) -> Result<()> {
+  let mut clipboard = Command::new("clip.exe").stdin(Stdio::piped()).spawn()?;
+  let mut clipboard_stdin = clipboard
+    .stdin
+    .take()
+    .ok_or_else(|| Error::new(Status::GenericFailure, "Could not get stdin handle for clip.exe"))?;
+
+  clipboard_stdin.write_all(s.as_bytes())?;
+
+  Ok(())
 }


### PR DESCRIPTION
Hello,

I tried to add support for WSL and SSH the way https://github.com/rgwood/clipboard-anywhere does for text clipboard.

The reason I didn't directly exposed clipboard-anywhere functions is because, when the clipboard value is set via a `Clipboard` instance, it isn't possible to access it again via a new instance of `Clipboard`. Thus, the tests wouldn't pass.
In addition, it allows still supporting images in the clipboard.