### PR TITLE
fix(clipboard): correct clipboard when used through SSH or WSL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ duct = "0.13.5"
 wsl = "0.1.0"
 napi = { version = "2", default-features = false, features = ["napi3"] }
 napi-derive = "2"
+once_cell = "1.17.1"
 
 [build-dependencies]
 napi-build = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ duct = "0.13.5"
 wsl = "0.1.0"
 napi = { version = "2", default-features = false, features = ["napi3"] }
 napi-derive = "2"
-once_cell = "1.17.1"
 
 [build-dependencies]
 napi-build = "2"


### PR DESCRIPTION
Hello,

First, sorry for the PR #18 that was buggy. When I noticed it, I put it in draft, but I should have written a clearer message!

This PR has been tested and it works both on WSL and through SSH. Here are some insights:
- Previously, the arboard clipboard was always initialized, which caused errors on WSL and SSH sessions. Now, it is initialized lazily and as a last resort.
- I discovered it was necessary to provide piped `stdout` and `stderr` output channels to the child process `clip.exe` on WSL otherwise the command fails.
- The way to set the clipboard through SSH uses an ANSI sequence (OSC52) that is not supported by all terminals (for example, not GNOME Terminal). However, I guess it is still better than nothing!