### PR TITLE
fix(ci): build real x86_64 darwin binary so darwin-x64 gets published (#118)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ jobs:
         settings:
           - host: macos-latest
             target: x86_64-apple-darwin
-            build: yarn build
+            build: yarn build --target x86_64-apple-darwin
           - host: windows-latest
             build: yarn build
             target: x86_64-pc-windows-msvc
@@ -119,8 +119,10 @@ jobs:
         settings:
           - host: windows-latest
             target: x86_64-pc-windows-msvc
+            architecture: x64
           - host: macos-latest
             target: x86_64-apple-darwin
+            architecture: x64
         node:
           - '22'
           - '24'
@@ -133,6 +135,7 @@ jobs:
           node-version: ${{ matrix.node }}
           check-latest: true
           cache: yarn
+          architecture: ${{ matrix.settings.architecture }}
       - name: Install dependencies
         run: yarn install
       - name: Download artifacts


### PR DESCRIPTION
Fixes #118.

## Root cause

`macos-latest` runners are now **Apple Silicon (arm64)**. The `x86_64-apple-darwin` build entry ran `yarn build` with **no `--target`**, so napi built for the host arch → an **arm64** binary mislabeled as x64.

```
x86_64-apple-darwin  →  macos-latest (arm64)  →  yarn build  →  clipboard.darwin-arm64.node  ✗
```

At publish time `napi artifacts` routes files by name, so **both** darwin artifacts (each `darwin-arm64.node`) landed in `npm/darwin-arm64/`, leaving `npm/darwin-x64/` with no binary. napi skipped publishing `@napi-rs/clipboard-darwin-x64@1.1.3`, but the main package still listed it in `optionalDependencies` → the broken 1.1.3.

**Evidence:** in the 1.1.3 release run, the two darwin artifacts are byte-identical in size (360757 both) — the same arm64 file twice. The test job masked it by running the "x64" (really arm64) binary on arm64 Node.

## Fix (matches the current napi-rs `package-template`)

- **build:** `yarn build` → `yarn build --target x86_64-apple-darwin` — cross-compiles a real x64 binary on the arm64 runner (target already installed via `dtolnay/rust-toolchain`).
- **test:** add `architecture: x64` and pass it to `setup-node` so an x64 Node (Rosetta) loads and actually exercises the x64 binary. Without this, the now-correct x64 binary can't load on the arm64 runner's Node and the release would fail.

## Follow-up

This stops the regression but 1.1.3 stays broken on npm (packages are immutable). A **1.1.4** release is still needed to ship all ten binaries — cut it *after* this lands on `main`, since the release build uses the CI at the version-bump commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)