### PR TITLE
chore(ci): publish via OIDC trusted publishing, drop dead NPM_TOKEN lines

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -262,13 +262,12 @@ jobs:
         shell: bash
       - name: Publish
         run: |
+          npm config set provenance true
           if git log -1 --pretty=%B | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+$";
           then
-            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
             npm publish --access public
           elif git log -1 --pretty=%B | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+";
           then
-            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
             npm publish --tag next --access public
           else
             echo "Not a release, skipping publish"


### PR DESCRIPTION
Adapts the release workflow to the npm **trusted publisher** (OIDC) that is already configured for all 11 packages.

## What was wrong

The publish step wrote `//registry.npmjs.org/:_authToken=$NPM_TOKEN` to `~/.npmrc`, but `NPM_TOKEN` was **never passed** to the step — its `env:` only sets `GITHUB_TOKEN`. So `$NPM_TOKEN` expanded to empty and the line wrote a useless credential. Releases already authenticate via **OIDC trusted publishing** (`id-token: write` + `npm@latest` + a trusted publisher on each package), which is why 1.1.3 published without a real token.

## Change

```diff
       - name: Publish
         run: |
+          npm config set provenance true
           if git log -1 --pretty=%B | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+$";
           then
-            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
             npm publish --access public
           elif git log -1 --pretty=%B | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+";
           then
-            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
             npm publish --tag next --access public
```

- Drop both vestigial `_authToken=$NPM_TOKEN` lines so nothing shadows OIDC.
- Add `npm config set provenance true` for provenance attestations (matches napi-rs's `package-template`).

## Why it's safe

- `permissions.id-token: write` is already set on the `publish` job → GitHub injects the OIDC request env; npm mints + exchanges the token against the registry's trusted-publisher record.
- `napi prepublish` publishes the 10 platform packages via `execSync('npm publish', { cwd: pkgDir, env: process.env })` — verified in `@napi-rs/cli` 3.7.2 — so they inherit the same OIDC path as the main package.
- Trusted publisher verified on **all 11** packages (repo `Brooooooklyn/Clipboard`, file `CI.yml`, permission `publish`).
- `contents: write` + `GITHUB_TOKEN` stay for napi's GitHub-release step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)